### PR TITLE
ci separation

### DIFF
--- a/prep/generate_mscaspt2.cc
+++ b/prep/generate_mscaspt2.cc
@@ -136,25 +136,27 @@ int main() {
   //  =   1/2(1/4<I|T^+fT|0> + 1/4<0|T^+fT|I>) - 1/2*(e0/4<I|T^+T|0> + e0/4<0|T^+T|I>) + 2*1/2 (1/4<I|T^+V|0> + 1/4<0|T^+V|I>) + 2*1/2 (1/4<I|T^+h1|0> + 1/4<0|T^+h1|I>)
   // using bracket symmetry in some terms
   shared_ptr<Equation> eq4(new Equation(theory, "dedcia", {dum, l_dagger, f, t_list}, 1.0, make_pair(true, false)));
-  shared_ptr<Equation> eq4b(new Equation(theory, "dedcic", {dum, l_dagger, t_list}, -1.0, "e0", make_pair(true, false)));
-  eq4->merge(eq4b);
   eq4->set_tree_type("residual", "deci");
   cout << eq4->generate();
+
+  shared_ptr<Equation> eq4b(new Equation(theory, "dedcic", {dum, l_dagger, t_list}, -1.0, "e0", make_pair(true, false)));
+  eq4b->set_tree_type("residual", "deci2");
+  cout << eq4b->generate();
 
   shared_ptr<Equation> eq4d(new Equation(theory, "dedcie", {dum, l_dagger, H}, 0.5, make_pair(true, false)));
   shared_ptr<Equation> eq4f(new Equation(theory, "dedcig", {dum, l_dagger, hc}, 1.0, make_pair(true, false)));
   eq4d->merge(eq4f);
-  eq4d->set_tree_type("residual", "deci2");
+  eq4d->set_tree_type("residual", "deci3");
   cout << eq4d->generate();
 
   shared_ptr<Equation> eq4e(new Equation(theory, "dedcif", {dum, l_dagger, H}, 0.5, make_pair(false, true)));
   shared_ptr<Equation> eq4g(new Equation(theory, "dedcih", {dum, l_dagger, hc}, 1.0, make_pair(false, true)));
   eq4e->merge(eq4g);
-  eq4e->set_tree_type("residual", "deci3");
+  eq4e->set_tree_type("residual", "deci4");
   cout << eq4e->generate();
 
   // done. generate the footer
-  cout << footer("", "", "", eq6->tree_label(), eq6a->tree_label(), eq7->tree_label(), eq4->tree_label(), eq4d->tree_label(), eq4e->tree_label()) << endl;
+  cout << footer("", "", "", eq6->tree_label(), eq6a->tree_label(), eq7->tree_label(), eq4->tree_label(), eq4b->tree_label(), eq4d->tree_label(), eq4e->tree_label()) << endl;
 
 
   return 0;

--- a/python/mscaspt2/gen_split.py
+++ b/python/mscaspt2/gen_split.py
@@ -1,7 +1,7 @@
 #!/opt/local/bin/python
 import string
 import os
-
+import re
 
 def header(n) :
     return "//\n\
@@ -59,19 +59,22 @@ for line in lines:
             tmp += "\n"
 tasks.append(tmp)
 
+p = re.compile('[0-9]+')
 tmp = ""
 num = 0
 chunk = 50
-for i in range(len(tasks)):
-    if (num != 0 and num % chunk == 0):
+n = 1
+for task in tasks:
+    num = int(p.search(task).group())
+    if (num != 0 and num >= n*chunk):
         n = num / chunk
         fout = open("MSCASPT2_gen" + str(n) + ".cc", "w")
         out = header(n) + tmp + footer
         fout.write(out)
         fout.close()
         tmp = ""
-    num = num+1
-    tmp = tmp + tasks[i];
+        n = n+1
+    tmp = tmp + task;
 
 n = (num-1) / chunk + 1
 fout = open("MSCASPT2_gen" + str(n) + ".cc", "w")

--- a/python/mscaspt2/header_split.py
+++ b/python/mscaspt2/header_split.py
@@ -1,6 +1,7 @@
 #!/opt/local/bin/python
 import string
 import os
+import re
 
 def header(n) :
     return "//\n\
@@ -100,19 +101,23 @@ for line in lines:
             tmp += "\n"
 tasks.append(tmp)
 
+p = re.compile('[0-9]+')
 tmp = ""
 num = 0
 chunk = 50
-for i in range(len(tasks)):
-    if (num != 0 and num % chunk == 0):
+n = 1
+for task in tasks:
+    num = int(p.search(task).group())
+    if (num != 0 and num >= n*chunk):
         n = num / chunk
         fout = open("MSCASPT2_tasks" + str(n) + ".h", "w")
         out = header(n) + tmp + footer
         fout.write(out)
         fout.close()
         tmp = ""
-    num = num+1
-    tmp = tmp + tasks[i];
+        n = n+1
+#    num = num+1
+    tmp = tmp + task;
 
 n = (num-1) / chunk + 1
 fout = open("MSCASPT2_tasks" + str(n) + ".h", "w")

--- a/python/mscaspt2/queue_split.py
+++ b/python/mscaspt2/queue_split.py
@@ -68,7 +68,7 @@ p = re.compile('make_[a-z0-9]+q')
 for task in tasks[0:-1]:
     tag = p.search(task).group()[5:]
     fout = open("MSCASPT2_" + tag + ".cc", "w")
-    out = header("_" + tag + "q") + insert() + header2() + task + footer
+    out = header("_" + tag) + insert() + header2() + task + footer
     fout.write(out)
     fout.close()
 

--- a/python/mscaspt2/tasks_split.py
+++ b/python/mscaspt2/tasks_split.py
@@ -3,7 +3,6 @@ import string
 import os
 import re
 
-
 def header(n) :
     return "//\n\
 // BAGEL - Brilliantly Advanced General Electronic Structure Library\n\

--- a/src/active.cc
+++ b/src/active.cc
@@ -137,16 +137,31 @@ bool Active::operator==(const Active& o) const {
 
 
 string Active::generate(const string indent, const string tag, const list<shared_ptr<const Index>> index, const list<shared_ptr<const Index>> merged, const string mlab, const bool use_blas) const {
-  stringstream tt;
+  stringstream dd;
 
   vector<string> in_tensors = required_rdm();
   if (!merged.empty()) {
     in_tensors.push_back(mlab);
   }
 
-  for (auto& i : rdm_)
-    tt << i->generate(indent, tag, index, merged, mlab, in_tensors, use_blas);
-  return tt.str();
+  for (auto& i : rdm_) {
+    dd << i->generate(indent, tag, index, merged, mlab, in_tensors, use_blas);
+  }
+  return dd.str();
+}
+
+string Active::generate_sources(const string indent, const string tag, const list<shared_ptr<const Index>> index, const list<shared_ptr<const Index>> merged, const string mlab, const bool use_blas) const {
+  stringstream dd;
+
+  vector<string> in_tensors = required_rdm();
+  if (!merged.empty()) {
+    in_tensors.push_back(mlab);
+  }
+
+  for (auto& i : rdm_) {
+    dd << i->generate_sources(indent, tag, index, merged, mlab, in_tensors, use_blas);
+  }
+  return dd.str();
 }
 
 

--- a/src/active.h
+++ b/src/active.h
@@ -76,6 +76,7 @@ class Active {
 
     /// This generate does get_block, sort_indices, and the merged (fock) multiplication for Gamma summation.
     std::string generate(const std::string indent, const std::string tag, const std::list<std::shared_ptr<const Index>> index, const std::list<std::shared_ptr<const Index>> merged = std::list<std::shared_ptr<const Index>>(), const std::string mlab = "", const bool use_blas = false) const;
+    std::string generate_sources(const std::string indent, const std::string tag, const std::list<std::shared_ptr<const Index>> index, const std::list<std::shared_ptr<const Index>> merged = std::list<std::shared_ptr<const Index>>(), const std::string mlab = "", const bool use_blas = false) const;
     /// Returns vector of int cooresponding to RDM numbers in Gamma. RDM0 is not included for non derivative trees.
     std::vector<std::string> required_rdm() const;
 

--- a/src/energy.cc
+++ b/src/energy.cc
@@ -295,4 +295,3 @@ OutStream Energy::generate_bc(const shared_ptr<BinaryContraction> i) const {
 
   return out;
 }
-

--- a/src/energy.h
+++ b/src/energy.h
@@ -46,12 +46,15 @@ class Energy : public Tree {
     std::string label() const override { return label_; }
 
     OutStream create_target(const int) const override { return OutStream(); }
+    OutStream create_target_ci(const int) const override { return OutStream(); }
     std::shared_ptr<Tensor> create_tensor(std::list<std::shared_ptr<const Index>>) const override { return  std::shared_ptr<Tensor>(); }
 
     OutStream generate_task(const int ip, const int ic, const std::vector<std::string>, const std::string scalar = "", const int i0 = 0, bool der = false, bool diagonal = false) const override;
+    OutStream generate_task_gamma(const int ip, const int ic, const std::vector<std::string>, const std::string scalar = "", const int i0 = 0, bool der = false, bool diagonal = false) const override { return OutStream(); }
     OutStream generate_compute_header(const int, const std::list<std::shared_ptr<const Index>> ti, const std::vector<std::shared_ptr<Tensor>>, const bool = false) const override;
     OutStream generate_compute_footer(const int, const std::list<std::shared_ptr<const Index>> ti, const std::vector<std::shared_ptr<Tensor>>, const bool dot) const override;
     OutStream generate_bc(std::shared_ptr<BinaryContraction>) const override;
+    OutStream generate_bc_sources(const int, const std::list<std::shared_ptr<const Index>> ti, const std::vector<std::shared_ptr<Tensor>>, const bool, const bool, const std::shared_ptr<BinaryContraction>) const override { return OutStream(); }
 
 };
 

--- a/src/forest.cc
+++ b/src/forest.cc
@@ -50,12 +50,12 @@ void Forest::filter_gamma() {
 
     for (auto& j : g) {
       bool found = false;
-      for (auto& k : gamma_) {
-        if ((*j) == (*k)) {
-          found = true;
-          break;
+        for (auto& k : gamma_) {
+          if ((*j) == (*k)) {
+            found = true;
+            break;
+          }
         }
-      }
       if (!found) gamma_.push_back(j);
     }
     prev = i->gamma();

--- a/src/rdm.h
+++ b/src/rdm.h
@@ -129,6 +129,9 @@ class RDM {
     /// Generate Gamma summation task, for both non-merged and merged case (RDM * f1 tensor multiplication).
     virtual std::string generate(std::string indent, const std::string itag, const std::list<std::shared_ptr<const Index>>& index, const std::list<std::shared_ptr<const Index>>& merged, const std::string mlab, std::vector<std::string> in_tensors, const bool use_blas) = 0;
 
+    /// Generate Gamma summation task, for both non-merged and merged case (RDM * f1 tensor multiplication).
+    virtual std::string generate_sources(std::string indent, const std::string itag, const std::list<std::shared_ptr<const Index>>& index, const std::list<std::shared_ptr<const Index>>& merged, const std::string mlab, std::vector<std::string> in_tensors, const bool use_blas) = 0;
+
     /// Copies this rdm, needs to be virtual as creates derived rdms.
     virtual std::shared_ptr<RDM> copy() const = 0;
 

--- a/src/rdm00.cc
+++ b/src/rdm00.cc
@@ -135,6 +135,12 @@ string RDM00::generate(string indent, const string tag, const list<shared_ptr<co
 }
 
 
+string RDM00::generate_sources(string indent, const string tag, const list<shared_ptr<const Index>>& index, const list<shared_ptr<const Index>>& merged,
+                       const string mlab, vector<string> in_tensors, const bool use_blas) {
+  return "";
+}
+
+
 string RDM00::generate_not_merged(string indent, const string tag, const list<shared_ptr<const Index>>& index, vector<string> in_tensors) {
   stringstream tt;
   tt << indent << "{" << endl;

--- a/src/rdm00.h
+++ b/src/rdm00.h
@@ -86,6 +86,8 @@ class RDM00 : public RDM {
 
     /// Generate Gamma summation task, for both non-merged and merged case (RDM * f1 tensor multiplication).
     std::string generate(std::string indent, const std::string itag, const std::list<std::shared_ptr<const Index>>& index, const std::list<std::shared_ptr<const Index>>& merged, const std::string mlab, std::vector<std::string> in_tensors, const bool use_blas) override;
+    /// Generate Gamma summation task, for both non-merged and merged case (RDM * f1 tensor multiplication).
+    std::string generate_sources(std::string indent, const std::string itag, const std::list<std::shared_ptr<const Index>>& index, const std::list<std::shared_ptr<const Index>>& merged, const std::string mlab, std::vector<std::string> in_tensors, const bool use_blas) override;
     /// Should not be needed for non-derivative rdms.
     std::list<std::shared_ptr<const Index>> conjugate() override { return std::list<std::shared_ptr<const Index>>(); }
 

--- a/src/rdmI0.h
+++ b/src/rdmI0.h
@@ -36,20 +36,32 @@ class RDMI0 : public RDM {
 
     /// Generate get block - source data to be added to target (move block).
     std::string make_get_block(std::string indent, std::string tag, std::string lbl, const std::list<std::shared_ptr<const Index>>& index);
+    /// Generate get block - source data to be added to target (move block).
+    std::string make_get_out_block(std::string indent, std::string tag, std::string lbl, const std::list<std::shared_ptr<const Index>>& index);
+    /// Generate get block - source data to be added to target (move block).
+    std::string make_out_block(std::string indent, std::string tag, std::string lbl, const std::list<std::shared_ptr<const Index>>& index);
     /// Generate sort_indices which makes array. This version has no addition (or factor multiplication-0111).
     std::string make_sort_indices(std::string indent, std::string tag, const std::list<std::shared_ptr<const Index>>& loop, const std::list<std::shared_ptr<const Index>>& index);
+    /// Generates RDM and merged (fock) tensor multipication.
+    std::string multiply_merge_sources(const std::string itag, std::string& indent,  const std::list<std::shared_ptr<const Index>>& merged, const std::list<std::shared_ptr<const Index>>& index);
     /// Generates RDM and merged (fock) tensor multipication.
     std::string multiply_merge(const std::string itag, std::string& indent,  const std::list<std::shared_ptr<const Index>>& merged, const std::list<std::shared_ptr<const Index>>& index);
     /// If delta case, also makes index loops then checks to see if merged-or-delta indices are in loops..
     std::string make_merged_loops(std::string& indent, const std::string tag, std::vector<std::string>& close, const std::list<std::shared_ptr<const Index>>& index, const bool overwrite = false);
     /// Adds merged (fock) tensor with indices, used by muliply_merge member, as well as ci index tensor multiplication in case of rdm0.
-    std::string fdata_mult(const std::string itag, const std::list<std::shared_ptr<const Index>>& merged, const std::list<std::shared_ptr<const Index>>& ci_index);
+    std::string fdata_mult(const std::string itag, const std::list<std::shared_ptr<const Index>>& merged, const std::list<std::shared_ptr<const Index>>& ci_index, const bool end = true);
 
     // virtual
     /// Generate entire task code for Gamma RDM summation.
     std::string generate_not_merged(std::string indent, const std::string tlab, const std::list<std::shared_ptr<const Index>>& loop, std::vector<std::string> in_tensors) override;
     /// Generates entire task code for Gamma RDM summation with merged object (additional tensor, here fock tensor) multiplication.
     std::string generate_merged(std::string indent, const std::string itag, const std::list<std::shared_ptr<const Index>>& index, const std::list<std::shared_ptr<const Index>>& merged, const std::string mlab, std::vector<std::string> in_tensors, const bool use_blas) override;
+
+    // for gamma - merged
+    /// Generate entire task code for Gamma RDM summation.
+    std::string generate_not_merged_sources(std::string indent, const std::string tlab, const std::list<std::shared_ptr<const Index>>& loop, std::vector<std::string> in_tensors);
+    /// Generates entire task code for Gamma RDM summation with merged object (additional tensor, here fock tensor) multiplication.
+    std::string generate_merged_sources(std::string indent, const std::string itag, const std::list<std::shared_ptr<const Index>>& index, const std::list<std::shared_ptr<const Index>>& merged, const std::string mlab, std::vector<std::string> in_tensors, const bool use_blas);
 
     /// Makes if statement in delta cases ie index equivalency check line.
     std::string make_delta_if(std::string& indent, std::vector<std::string>& close) override;
@@ -61,6 +73,7 @@ class RDMI0 : public RDM {
 
     // for task summation line
     /// Generates odata (Gamma) part of for summation ie LHS in equations gamma += rdm or gamma += rdm * f1
+    std::string make_odata_sources(const std::string itag, std::string& indent, const std::list<std::shared_ptr<const Index>>& index);
     std::string make_odata(const std::string itag, std::string& indent, const std::list<std::shared_ptr<const Index>>& index) override;
 
     /// Do blas multiplication of Gamma and fock tensors...not implemented yet for subtask code!
@@ -91,6 +104,9 @@ class RDMI0 : public RDM {
 
     /// Generate Gamma summation task, for both non-merged and merged case (RDM * f1 tensor multiplication).
     std::string generate(std::string indent, const std::string itag, const std::list<std::shared_ptr<const Index>>& index, const std::list<std::shared_ptr<const Index>>& merged, const std::string mlab, std::vector<std::string> in_tensors, const bool use_blas) override;
+
+    /// Generate Gamma summation task, for both non-merged and merged case (RDM * f1 tensor multiplication).
+    std::string generate_sources(std::string indent, const std::string itag, const std::list<std::shared_ptr<const Index>>& index, const std::list<std::shared_ptr<const Index>>& merged, const std::string mlab, std::vector<std::string> in_tensors, const bool use_blas) override;
 
 
 };

--- a/src/residual.h
+++ b/src/residual.h
@@ -34,7 +34,6 @@ namespace smith {
 class Residual : public Tree {
   protected:
 
-
   public:
     /// Construct tree of equation pointers and set tree label.
     Residual(const std::shared_ptr<Equation> eq, std::string lab = "") : Tree(eq, lab) { }
@@ -46,12 +45,17 @@ class Residual : public Tree {
     std::string label() const override { return label_; }
 
     OutStream create_target(const int) const override;
+    OutStream create_target_ci(const int) const override;
     std::shared_ptr<Tensor> create_tensor(std::list<std::shared_ptr<const Index>>) const override;
 
     OutStream generate_task(const int ip, const int ic, const std::vector<std::string>, const std::string scalar = "", const int i0 = 0, bool der = false, bool diagonal = false) const override;
+    OutStream generate_task_gamma(const int ip, const int ic, const std::vector<std::string>, const std::string scalar = "", const int i0 = 0, bool der = false, bool diagonal = false) const override;
     OutStream generate_compute_header(const int, const std::list<std::shared_ptr<const Index>> ti, const std::vector<std::shared_ptr<Tensor>>, const bool = false) const override;
     OutStream generate_compute_footer(const int, const std::list<std::shared_ptr<const Index>> ti, const std::vector<std::shared_ptr<Tensor>>, const bool dot) const override;
     OutStream generate_bc(const std::shared_ptr<BinaryContraction>) const override;
+    OutStream generate_bc_sources(const int, const std::list<std::shared_ptr<const Index>> ti, const std::vector<std::shared_ptr<Tensor>>, const bool, const bool, const std::shared_ptr<BinaryContraction>) const override;
+    OutStream generate_header_sources(const int, const std::list<std::shared_ptr<const Index>> ti, const std::vector<std::shared_ptr<Tensor>>, const bool no_outside = false) const;
+    OutStream generate_footer_sources(const int, const std::list<std::shared_ptr<const Index>> ti, const std::vector<std::shared_ptr<Tensor>>, const bool dot) const;
 
 
 };

--- a/src/tensor.cc
+++ b/src/tensor.cc
@@ -158,8 +158,35 @@ string Tensor::constructor_str(const bool diagonal) const {
   return ss.str();
 }
 
+string Tensor::constructor_str_ci(const bool diagonal) const {
+  stringstream ss;
+  string indent = "";
+  // ci0 index is now propagated to Itensor_1...5
+  for (int j = 0; j != 5; ++j) {
+    if (j != 0)
+    ss << endl;
+    ss << indent << "  vector<IndexRange> " << label() << "_" << j << "_index";
+    int no;
+    if (j > 3) no = 3;
+    else no = j%4;
 
-string Tensor::generate_get_block(const string cindent, const string lab, const string tlab, const bool move, const bool noscale) const {
+    if (no) {
+      ss << " = {";
+      for (int i = 0; i != no; ++i) {
+        ss << "active_, active_, ";
+      }
+      ss << "active_, active_";
+      ss << "};" << endl;
+    } else {
+      ss << ";" << endl;
+    }
+    ss << indent << "  " << (diagonal ? "" : "auto ") << label() << "_" << j << " = make_shared<Tensor>(" << label() << "_" << j << "_index);";
+  }
+  return ss.str();
+}
+
+
+string Tensor::generate_get_block(const string cindent, const string lab, const string tlab, const bool move, const bool noscale, const int number, const bool merged, const list<shared_ptr<const Index>>& mergedlist) const {
   string lbl = label();
   if (lbl == "proj") lbl = "r";
   size_t found = lbl.find("dagger");
@@ -187,13 +214,26 @@ string Tensor::generate_get_block(const string cindent, const string lab, const 
       tt << cindent << "std::unique_ptr<" << DataType << "[]> " << lab << "data(new " << DataType << "[" << tlab << "->get_size(";
     string listind = "";
     if (found != string::npos) {
+      int no = 0;
       for (auto i = index_.begin(); i != index_.end(); ++i) {
+        if (number==-1 || no==(number+1)) break;
         if (i != index_.begin()) listind += ", ";
         listind += (*i)->str_gen();
+        ++no;
       }
     } else {
+      int no = 0;
       for (auto i = index_.rbegin(); i != index_.rend(); ++i) {
+        if (number==-1 || no==(number+1)) break;
         if (i != index_.rbegin()) listind += ", ";
+        listind += (*i)->str_gen();
+        ++no;
+      }
+    }
+    if (merged) {
+      for (auto i = mergedlist.rbegin(); i != mergedlist.rend(); ++i) {
+        if (index_.size()!=0 || i != mergedlist.rbegin())
+          listind += ", ";
         listind += (*i)->str_gen();
       }
     }
@@ -396,33 +436,63 @@ pair<string, string> Tensor::generate_dim(const list<shared_ptr<const Index>>& d
 }
 
 
-string Tensor::generate_active(string indent, const string tag, const int ninptensors, const bool use_blas) const {
+string Tensor::generate_active_sources(string indent, const string tag, const int ninptensors, const bool use_blas, const shared_ptr<Tensor> source) const {
   assert(label_.find("Gamma") != string::npos);
-  stringstream tt;
+  stringstream dd;
   if (!merged_) {
-    tt << active()->generate(indent, tag, index());
+    dd << active()->generate_sources(indent, tag, index());
   } else {
 
 #ifdef debug_tasks
-    tt << indent <<"// associated with merged" << endl;
+    dd << indent <<"// associated with merged" << endl;
 #endif
 
     // add fdata
     list<shared_ptr<const Index>>& merged = merged_->index();
     // fdata tensor should be last to mirror gamma footer
-    tt << indent << "std::unique_ptr<" << DataType << "[]> fdata = in("<< ninptensors-1 << ")->get_block(";
+    dd << indent << "std::unique_ptr<" << DataType << "[]> fdata = in(1)->get_block(";
     for (auto j = merged.rbegin(); j != merged.rend(); ++j) {
-      if (j != merged.rbegin()) tt << ", ";
-      tt << (*j)->str_gen();
+      if (j != merged.rbegin()) dd << ", ";
+      dd << (*j)->str_gen();
     }
-    tt << ");" << endl;
+    dd << ");" << endl;
+
+    // generate merged and/or rdm
+    dd << active()->generate_sources(indent, tag, index(), merged_->index(), merged_->label(), use_blas);
+
+  }
+  return dd.str();
+}
+
+
+
+string Tensor::generate_active(string indent, const string tag, const int ninptensors, const bool use_blas) const {
+  assert(label_.find("Gamma") != string::npos);
+  stringstream dd;
+  if (!merged_) {
+    dd << active()->generate(indent, tag, index());
+  } else {
+
+#ifdef debug_tasks
+    dd << indent <<"// associated with merged" << endl;
+#endif
+
+    // add fdata
+    list<shared_ptr<const Index>>& merged = merged_->index();
+    // fdata tensor should be last to mirror gamma footer
+    dd << indent << "std::unique_ptr<" << DataType << "[]> fdata = in("<< ninptensors-1 << ")->get_block(";
+    for (auto j = merged.rbegin(); j != merged.rend(); ++j) {
+      if (j != merged.rbegin()) dd << ", ";
+      dd << (*j)->str_gen();
+    }
+    dd << ");" << endl;
 
     if (use_blas) {
-      tt << indent << "std::unique_ptr<" << DataType << "[]> fdata_sorted(new " << DataType << "["<< merged_->label() << "->get_size(fhash)]);" << endl;
+      dd << indent << "std::unique_ptr<" << DataType << "[]> fdata_sorted(new " << DataType << "["<< merged_->label() << "->get_size(fhash)]);" << endl;
 
       // make sort_indices for merged op
       vector<int> done;
-      tt << indent << "sort_indices<";
+      dd << indent << "sort_indices<";
       for (auto i = merged.begin(); i != merged.end(); ++i) {
         int cnt = 0;
         for (auto j = merged.rbegin(); j != merged.rend(); ++j, ++cnt) {
@@ -438,25 +508,24 @@ string Tensor::generate_active(string indent, const string tag, const int ninpte
       }
       // write out
       for (auto& i : done)
-        tt << i << ",";
+        dd << i << ",";
 
-      tt << "0,1,1,1";
+      dd << "0,1,1,1";
 
       // add source data dimensions
-      tt << ">(fdata, fdata_sorted, " ;
+      dd << ">(fdata, fdata_sorted, " ;
       for (auto iter = merged.rbegin(); iter != merged.rend(); ++iter) {
-        if (iter != merged.rbegin()) tt << ", ";
-          tt << (*iter)->str_gen() << ".size()";
+        if (iter != merged.rbegin()) dd << ", ";
+          dd << (*iter)->str_gen() << ".size()";
       }
-      tt << ");" << endl;
+      dd << ");" << endl;
     }
 
     // generate merged and/or rdm
-    tt << active()->generate(indent, tag, index(), merged_->index(), merged_->label(), use_blas);
-
+    dd << active()->generate(indent, tag, index(), merged_->index(), merged_->label(), use_blas);
 
   }
-  return tt.str();
+  return dd.str();
 }
 
 
@@ -470,12 +539,9 @@ string Tensor::generate_loop(string& indent, vector<string>& close) const {
   return tt.str();
 }
 
-
-OutStream Tensor::generate_gamma(const int ic, const bool use_blas, const bool der) const {
-  // TODO split generate_gamma function up to header/body/footer once working (too large now)
+OutStream Tensor::generate_gamma_sources(const int ic, const bool use_blas, const bool der, const shared_ptr<Tensor> source, const list<shared_ptr<const Index>> di) const {
   assert(label_.find("Gamma") != string::npos);
   OutStream out;
-
 
   // determine number of task loops to be separeted, if merged combine
   int nindex;
@@ -497,8 +563,203 @@ OutStream Tensor::generate_gamma(const int ic, const bool use_blas, const bool d
     ninptensors = rdmn.size();
   }
 
+  out << generate_gamma_header_sources(ic, use_blas, der, nindex);
+  out << generate_gamma_body_sources(ic, use_blas, der, nindex, ninptensors, merged, source, di);
+  out << generate_gamma_footer_sources(ic, use_blas, der, nindex, ninptensors, merged);
 
-  //////////// gamma header ////////////
+  return out;
+}
+
+
+OutStream Tensor::generate_gamma(const int ic, const bool use_blas, const bool der) const {
+  assert(label_.find("Gamma") != string::npos);
+  OutStream out;
+
+  // determine number of task loops to be separeted, if merged combine
+  int nindex;
+  list<shared_ptr<const Index>> merged;
+
+  if (merged_) {
+    merged = merged_->index();
+    nindex = index_.size() + merged.size();
+  } else {
+    nindex = index_.size();
+  }
+
+  // determine number of tensors
+  vector<string> rdmn = active()->required_rdm();
+  int ninptensors;
+  if (merged_) {
+    ninptensors = rdmn.size()+1;
+  } else {
+    ninptensors = rdmn.size();
+  }
+
+  out << generate_gamma_header(ic, use_blas, der, nindex, ninptensors);
+  out << generate_gamma_body(ic, use_blas, der, nindex, ninptensors, merged);
+  out << generate_gamma_footer(ic, use_blas, der, nindex, ninptensors, merged);
+
+  return out;
+}
+
+OutStream Tensor::generate_gamma_header_sources(const int ic, const bool use_blas, const bool der, const int nindex) const {
+  OutStream out;
+
+#ifdef debug_tasks
+  out.tt << "class Task" << ic << " : public Task {" <<  "  // merged with gamma" << endl;
+#else
+  out.tt << "class Task" << ic << " : public Task {" << endl;
+#endif
+  out.tt << "  protected:" << endl;
+  out.tt << "    std::array<std::shared_ptr<Tensor>,5> out_;" << endl;
+  out.tt << "    std::array<std::shared_ptr<const Tensor>," << (merged_? "2":"1") << "> in_;" << endl;
+  out.tt << "    class Task_local : public SubTask_Merged<" << nindex << "," << (merged_? "2":"1") << ",5> {" << endl;    // five here is output tensors
+  out.tt << "      protected:" << endl;
+  out.tt << "        const std::array<std::shared_ptr<const IndexRange>," << (der ? "4" : "3") << "> range_;" << endl;
+  out.tt << endl;
+
+  out.tt << "        const Index& b(const size_t& i) const { return this->block(i); }" << endl;
+  out.tt << "        std::shared_ptr<const Tensor> in(const size_t& i) const { return this->in_tensor(i); }" << endl;
+  out.tt << "        std::shared_ptr<Tensor> out(const size_t& i) { return this->out_tensor(i); }" << endl;
+  out.tt << endl;
+  out.tt << "      public:" << endl;
+  out.tt << "        Task_local(const std::array<const Index," << nindex << ">& block, const std::array<std::shared_ptr<const Tensor>," << (merged_? "2":"1") <<  ">& in," << endl;
+  out.tt << "                   const std::array<std::shared_ptr<Tensor>,5>& out,";
+  out.tt << " std::array<std::shared_ptr<const IndexRange>," << (der ? "4" : "3") << ">& ran)" << endl;
+  out.tt << "          : SubTask_Merged<" << nindex << "," << (merged_? "2":"1") << ",5>(block, in, out), range_(ran) { }" << endl;
+  out.tt << endl;
+  out.tt << endl;
+  out.tt << "        void compute() override;" << endl;
+
+  out.dd << "void Task" << ic << "::Task_local::compute() {" << endl;
+
+  return out;
+}
+
+
+OutStream Tensor::generate_gamma_body_sources(const int ic, const bool use_blas, const bool der, const int nindex, const int ninptensors, const list<shared_ptr<const Index>>& merged, const shared_ptr<Tensor> source, const list<shared_ptr<const Index>> di) const {
+  OutStream out;
+
+  string indent ="  ";
+  int bcnt = 0;
+  for (auto i = index_.rbegin(); i != index_.rend(); ++i, bcnt++) {
+    out.dd << indent << "const Index " << (*i)->str_gen() << " = b(" << bcnt << ");" << endl;
+  }
+  if (merged_) {
+    for (auto i = merged.rbegin(); i != merged.rend(); ++i, bcnt++)
+      out.dd << indent << "const Index " << (*i)->str_gen() << " = b(" << bcnt << ");" << endl;
+  }
+
+  // generate gamma get block, true does a move_block
+
+  out.dd << source->generate_get_block(indent, "i0", "in(0)");
+  out.dd << source->generate_sort_indices(indent, "i0", "in(0)", di) << endl;
+
+#ifdef debug_tasks // if needed, eg debug
+  out.dd << indent << "// tensor label (calculated on-the-fly): " << label() << endl;
+#endif
+  // TODO currently not considering blas
+  if (merged_) {
+    if (use_blas && !index_.empty()) out.dd << generate_scratch_area(indent, "o", "out", true);
+  }
+  // now generate codes for rdm
+  out.dd << generate_active_sources(indent, "o", ninptensors, use_blas, source);
+  out.dd << "}" << endl << endl << endl;
+
+  return out;
+}
+
+
+OutStream Tensor::generate_gamma_footer_sources(const int ic, const bool use_blas, const bool der, const int nindex, const int ninptensors, const list<shared_ptr<const Index>>& merged) const {
+  OutStream out;
+
+  out.tt << "    };" << endl;
+  out.tt << "" << endl;
+  out.tt << "    std::vector<std::shared_ptr<Task_local>> subtasks_;" << endl;
+  out.tt << "" << endl;
+
+  out.tt << "    void compute_() override {" << endl;
+  out.tt << "      if (!out_[0]->allocated())" << endl;
+  out.tt << "        out_[0]->allocate();" << endl;
+  out.tt << "      if (!out_[1]->allocated())" << endl;
+  out.tt << "        out_[1]->allocate();" << endl;
+  out.tt << "      if (!out_[2]->allocated())" << endl;
+  out.tt << "        out_[2]->allocate();" << endl;
+  out.tt << "      if (!out_[3]->allocated())" << endl;
+  out.tt << "        out_[3]->allocate();" << endl;
+  out.tt << "      if (!out_[4]->allocated())" << endl;
+  out.tt << "        out_[4]->allocate();" << endl;
+  out.tt << "      for (auto& i : subtasks_) i->compute();" << endl;
+  out.tt << "    }" << endl << endl;
+
+  out.tt << "  public:" << endl;
+  out.tt << "    Task" << ic << "(std::vector<std::shared_ptr<Tensor>> t, std::array<std::shared_ptr<const IndexRange>," << (der ? "4" : "3") << "> range);" << endl;
+
+  out.cc << "Task" << ic << "::Task" << ic << "(vector<shared_ptr<Tensor>> t, array<shared_ptr<const IndexRange>," << (der ? "4" : "3") << "> range) {" << endl;
+  out.cc << "  array<shared_ptr<const Tensor>," << (merged_? "2" : "1") << "> in = {{";
+
+  // write out tensors in increasing order
+  for (auto i = 1;  i < (merged_? 2 : 1) + 1; ++i)
+    out.cc << "t[" << i+4 << "]" << (i == (merged_? 2 : 1) ? "" : ", ");
+  out.cc << "}};" << endl;
+
+  out.cc << "  array<shared_ptr<Tensor>,5> out = {{t[0], t[1], t[2], t[3], t[4]}};" << endl;
+  out.cc << "  in_ = in;" << endl;
+  out.cc << "  out_ = out;" << endl << endl;
+
+  // over original outermost indices
+  if (!index_.empty()) {
+    out.cc << "  subtasks_.reserve(";
+    for (auto i =index_.rbegin(); i != index_.rend(); ++i) {
+      if (i != index_.rbegin()) out.cc << "*";
+      out.cc << (*i)->generate_range() << "->nblock()";
+    }
+    if (merged_){
+      for (auto i = merged.rbegin(); i != merged.rend(); ++i) {
+        out.cc << "*" << (*i)->generate_range() << "->nblock()";
+      }
+    }
+    out.cc << ");" << endl;
+  }
+  // loops
+  string cindent = "  ";
+  for (auto i = index_.rbegin(); i != index_.rend(); ++i, cindent += "  ")
+    out.cc << cindent << "for (auto& " << (*i)->str_gen() << " : *" << (*i)->generate_range() << ")" << endl;
+  if (merged_)
+    for (auto i = merged.rbegin(); i != merged.rend(); ++i, cindent += "  ")
+      out.cc << cindent << "for (auto& " << (*i)->str_gen() << " : *" << (*i)->generate_range() << ")" << endl;
+  // parallel if
+  string listind = "";
+  for (auto i = index_.rbegin(); i != index_.rend(); ++i) {
+    if (i != index_.rbegin()) listind += ", ";
+    listind += (*i)->str_gen();
+  }
+  // the input t decides whether it is local or not --- wrong when merged
+  out.cc << cindent << "if (t[5]->is_local("<< listind << "))" << endl;
+  cindent += "  ";
+  // add subtasks
+  out.cc << cindent  << "subtasks_.push_back(make_shared<Task_local>(array<const Index," << nindex << ">{{" << listind;
+  if (merged_) {
+    out.cc << (index_.empty() ? "" : ", ");
+    for (auto i = merged.rbegin(); i != merged.rend(); ++i) {
+      out.cc << (*i)->str_gen();
+      if (i != --merged.rend()) out.cc << ", ";
+    }
+  }
+  out.cc << "}}, in, out, range));" << endl;
+  out.cc << "}" << endl << endl << endl;
+
+  out.tt << "    ~Task" << ic << "() {}" << endl;
+  out.tt << "};" << endl << endl;
+
+
+  return out;
+}
+
+
+OutStream Tensor::generate_gamma_header(const int ic, const bool use_blas, const bool der, const int nindex, const int ninptensors) const {
+  OutStream out;
+
 #ifdef debug_tasks
   out.tt << "class Task" << ic << " : public Task {" <<  "  // associated with gamma" << endl;
 #else
@@ -526,7 +787,12 @@ OutStream Tensor::generate_gamma(const int ic, const bool use_blas, const bool d
 
   out.dd << "void Task" << ic << "::Task_local::compute() {" << endl;
 
-  //////////// gamma body  ////////////
+  return out;
+}
+
+OutStream Tensor::generate_gamma_body(const int ic, const bool use_blas, const bool der, const int nindex, const int ninptensors, const list<shared_ptr<const Index>>& merged) const {
+  OutStream out;
+
   string indent ="  ";
   // map indices
   int bcnt = 0;
@@ -538,7 +804,7 @@ OutStream Tensor::generate_gamma(const int ic, const bool use_blas, const bool d
   }
 
   // generate gamma get block, true does a move_block
-  out.dd << generate_get_block(indent, "o", "out()", true, true); // first true means move, second true means we don't scale
+  out.dd << generate_get_block(indent, "o", "out()", /*move=*/true, /*noscale=*/true);
   if (merged_) {
     if (use_blas && !index_.empty()) out.dd << generate_scratch_area(indent, "o", "out", true);
   }
@@ -552,7 +818,12 @@ OutStream Tensor::generate_gamma(const int ic, const bool use_blas, const bool d
   out.dd << ");" << endl;
   out.dd << "}" << endl << endl << endl;
 
-  //////////// gamma footer  ////////////
+  return out;
+}
+
+OutStream Tensor::generate_gamma_footer(const int ic, const bool use_blas, const bool der, const int nindex, const int ninptensors, const list<shared_ptr<const Index>>& merged) const {
+  OutStream out;
+
   out.tt << "    };" << endl;
   out.tt << "" << endl;
   out.tt << "    std::vector<std::shared_ptr<Task_local>> subtasks_;" << endl;
@@ -623,7 +894,6 @@ OutStream Tensor::generate_gamma(const int ic, const bool use_blas, const bool d
   out.tt << "    ~Task" << ic << "() {}" << endl;
   out.tt << "};" << endl << endl;
 
+
   return out;
 }
-
-

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -106,7 +106,6 @@ class Tensor {
     /// Used to reindex tensor in absorb_ket().
     void set_index(std::list<std::shared_ptr<const Index>> i) { index_ = i; }
 
-
     /// Returns tensor prefactor.
     double factor() const { return factor_; }
     /// Returns scalar name.
@@ -139,9 +138,11 @@ class Tensor {
     std::map<int, int> num_map() const { return num_map_; }
 
     /// Generates string for constructor for tensors in Method.cc file
+    std::string constructor_str_ci(const bool diagonal = false) const;
+    /// Generates string for constructor for tensors in Method.cc file
     std::string constructor_str(const bool diagonal = false) const;
     /// Generates code for get_block - source block to be added later to target (move) block.
-    std::string generate_get_block(const std::string, const std::string, const std::string, const bool move = false, const bool noscale = false) const;
+    std::string generate_get_block(const std::string, const std::string, const std::string, const bool move = false, const bool noscale = false, int number = -2, bool merged = false, const std::list<std::shared_ptr<const Index>>& mergedlist = (std::list<std::shared_ptr<const Index>>())) const;
     /// Generate code for unique_ptr scratch arrays.
     std::string generate_scratch_area(const std::string, const std::string, const std::string tensor_lab, const bool zero = false) const;
     /// Generate code for sort_indices. Based on operations needed to sort input tensor to output tensor.
@@ -153,10 +154,19 @@ class Tensor {
     std::pair<std::string, std::string> generate_dim(const std::list<std::shared_ptr<const Index>>&) const;
     /// Generates code for RDMs.
     std::string generate_active(const std::string indent, const std::string tag, const int ninptensors, const bool) const;
+    std::string generate_active_sources(const std::string indent, const std::string tag, const int ninptensors, const bool, const std::shared_ptr<Tensor>) const;
     /// Generate for loops.
     std::string generate_loop(std::string&, std::vector<std::string>&) const;
     /// Generate code for Gamma task.
+    OutStream generate_gamma_sources(const int, const bool use_blas, const bool der, const std::shared_ptr<Tensor> source, const std::list<std::shared_ptr<const Index>> di) const;
+    OutStream generate_gamma_header_sources(const int, const bool use_blas, const bool der, const int nindex) const;
+    OutStream generate_gamma_body_sources(const int, const bool, const bool, const int, const int, const std::list<std::shared_ptr<const Index>>&, const std::shared_ptr<Tensor> source, const std::list<std::shared_ptr<const Index>> di) const;
+    OutStream generate_gamma_footer_sources(const int, const bool, const bool, const int, const int, const std::list<std::shared_ptr<const Index>>&) const;
+
     OutStream generate_gamma(const int, const bool use_blas, const bool der) const;
+    OutStream generate_gamma_header(const int, const bool use_blas, const bool der, const int nindex, const int ninptensors) const;
+    OutStream generate_gamma_body(const int, const bool, const bool, const int, const int, const std::list<std::shared_ptr<const Index>>&) const;
+    OutStream generate_gamma_footer(const int, const bool, const bool, const int, const int, const std::list<std::shared_ptr<const Index>>&) const;
     /// Returns Gamma number.
     int num() const { assert(is_gamma()); return num_; }
     /// Set Gamma number.

--- a/src/tree.h
+++ b/src/tree.h
@@ -251,8 +251,27 @@ class Tree {
     /// Generate code by stepping through op and bc.
     std::tuple<OutStream, int, int, std::vector<std::shared_ptr<Tensor>>>
         generate_steps(const std::string indent, int tcnt, int t0, const std::list<std::shared_ptr<Tensor>> gamma, std::vector<std::shared_ptr<Tensor>> itensors) const;
+    /// Generate task header for only CI in Residual.
+    OutStream generate_task_ci(const int ic, const std::vector<std::shared_ptr<Tensor>>, const std::list<std::shared_ptr<Tensor>> g, const int i0 = 0, const bool diagonal = false) const;
+    OutStream generate_task_gamma(const int ic, const std::vector<std::shared_ptr<Tensor>>, const std::list<std::shared_ptr<Tensor>> g, const int i0 = 0, const bool diagonal = false, const bool gamma = true, const bool merged = false) const;
     /// Generate task in dependency file with ic as task number. Caution also have a virtual generate_task.
     OutStream generate_task(const int ic, const std::vector<std::shared_ptr<Tensor>>, const std::list<std::shared_ptr<Tensor>> g, const int i0 = 0, const bool diagonal = false) const;
+
+    /// These functions are separated out for readability
+    std::tuple<OutStream, int, int, std::vector<std::shared_ptr<Tensor>>>
+        generate_task_list_zero(int tcnt, int t0, const std::list<std::shared_ptr<Tensor>> gamma, std::vector<std::shared_ptr<Tensor>> itensors) const;
+
+    std::tuple<OutStream, int, int, std::vector<std::shared_ptr<Tensor>>>
+        binarycontraction_generate_zero_ci(std::shared_ptr<BinaryContraction> j, int tcnt, int t0, const std::list<std::shared_ptr<Tensor>> gamma, std::vector<std::shared_ptr<Tensor>> itensors) const;
+
+    std::tuple<OutStream, int, int, std::vector<std::shared_ptr<Tensor>>>
+        binarycontraction_generate_zero(std::shared_ptr<BinaryContraction> j, int tcnt, int t0, const std::list<std::shared_ptr<Tensor>> gamma, std::vector<std::shared_ptr<Tensor>> itensors) const;
+
+    std::tuple<OutStream, int, std::vector<std::shared_ptr<Tensor>>>
+        binarycontraction_generate_gamma(std::shared_ptr<BinaryContraction> i, int tcnt, const std::list<std::shared_ptr<Tensor>> gamma, int t0, std::vector<std::shared_ptr<Tensor>> itensors) const;
+
+    std::tuple<OutStream, int, std::vector<std::shared_ptr<Tensor>>>
+        binarycontraction_generate(std::shared_ptr<BinaryContraction> i, int tcnt, const std::list<std::shared_ptr<Tensor>> gamma, int t0, std::vector<std::shared_ptr<Tensor>> itensors) const;
 
     /// Generate task for operator task (ie not a binary contraction task). Dagger arguement refers to front subtree used at top level.
     OutStream generate_compute_operators(const std::shared_ptr<Tensor>, const std::vector<std::shared_ptr<Tensor>>, const bool dagger = false) const;
@@ -260,17 +279,21 @@ class Tree {
     // Tree specific code generation moved to derived classes.
     /// Needed for zero level target tensors. Generates a Task '0' ie task to initialize top (zero depth) target tensor also sets up dependency queue.
     virtual OutStream create_target(const int i) const = 0;
+    virtual OutStream create_target_ci(const int i) const = 0;
     /// Create new tensor based on derived tree.
     virtual std::shared_ptr<Tensor> create_tensor(std::list<std::shared_ptr<const Index>>) const = 0;
 
     /// Generate a task. Here ip is the tag of parent, ic is the tag of this.
     virtual OutStream generate_task(const int ip, const int ic, const std::vector<std::string>, const std::string scalar = "", const int i0 = 0, bool der = false, bool diagonal = false) const = 0;
+    virtual OutStream generate_task_gamma(const int ip, const int ic, const std::vector<std::string>, const std::string scalar = "", const int i0 = 0, bool der = false, bool diagonal = false) const = 0;
     /// Generate task header.
     virtual OutStream generate_compute_header(const int, const std::list<std::shared_ptr<const Index>> ti, const std::vector<std::shared_ptr<Tensor>>, const bool = false) const = 0;
     /// Generate task footer.
     virtual OutStream generate_compute_footer(const int, const std::list<std::shared_ptr<const Index>> ti, const std::vector<std::shared_ptr<Tensor>>, const bool dot) const = 0;
     /// Generate Binary contraction code.
     virtual OutStream generate_bc(const std::shared_ptr<BinaryContraction>) const = 0;
+    /// With sources
+    virtual OutStream generate_bc_sources(const int, const std::list<std::shared_ptr<const Index>> ti, const std::vector<std::shared_ptr<Tensor>>, const bool, const bool, const std::shared_ptr<BinaryContraction>) const = 0;
 
 };
 


### PR DESCRIPTION
Separate CI derivative (dE/dc_(I,M)) into the form of Beff * <I|E_(ij,kl,mn,op)|0> contractable Beff. (BAGEL code version: #b3bf6701724738e3e8a8a9eb0d09844efb7bb045 ) The code for contracting Beff with RDM derivatives can be also found in BAGEL (src/smith/caspt2/MSCASPT2_contract??.?).