### PR TITLE
SMITH3 up-to-date

### DIFF
--- a/src/forest.cc
+++ b/src/forest.cc
@@ -206,6 +206,7 @@ OutStream Forest::generate_gammas() const {
   // All the gamma tensors (for all trees) should be defined here. Only distinct Gammas are computed.
   out.ss << endl;
   for (auto& i : gamma_) {
+    if (i->der()) continue;
 
     i->set_num(icnt);
     assert(i->label().find("Gamma") != string::npos);

--- a/src/forest.cc
+++ b/src/forest.cc
@@ -193,7 +193,7 @@ OutStream Forest::generate_headers() const {
   out.gg << "using namespace std;" << endl;
   out.gg << "using namespace bagel;" << endl;
   out.gg << "using namespace bagel::SMITH;" << endl;
-  out.gg << "using namespace bagel::SMITH::" << forest_name_ << ";" << endl << endl;
+  out.gg << "using bagel::SMITH::" << forest_name_ << "::FutureTensor;" << endl << endl;
 
   return out;
 }

--- a/src/tensor.cc
+++ b/src/tensor.cc
@@ -575,6 +575,9 @@ OutStream Tensor::generate_gamma(const int ic, const bool use_blas, const bool d
   assert(label_.find("Gamma") != string::npos);
   OutStream out;
 
+  // if it is derivative code, do not generate anything
+  if (der) return out;
+
   // determine number of task loops to be separeted, if merged combine
   int nindex;
   list<shared_ptr<const Index>> merged;


### PR DESCRIPTION
This is a pull request to keep SMITH3 up-to-date. With these small changes, SMITH3 no longer generates code for gammas that are not in use. Also, it makes the generated code ICC compilable.